### PR TITLE
Add pull-up resistor

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -44,7 +44,8 @@ Add the `calibrate_offsets.cfg` sample below, read the comments, and make sure y
 # These two values should be changed or checked.
 #
 # 'pin' should reference the pin used for Nudge.
-pin: z:PC0
+# Add a pull-up resistor because this is like an endstop.
+pin: ^z:PC0
 # 'spread' is the amount of X or Y motion used in the probing sequence.
 # Think of it as the clearance from the center, to accomodate the pin's diameter and any
 # initial starting-point inaccuracy.


### PR DESCRIPTION
This pull-up resistor should help with electrical noise. Compare to the Voron 0 Z endstop configuration for example https://github.com/VoronDesign/Voron-0/blob/Voron0.2r1/Firmware/bigtreetech-skr-pico-v1.0.cfg

I think this isn't required for the BTT boards I checked (pico and octopus pro), if using the endstop port, but it isn't harmful.